### PR TITLE
Fix hash collision vulnerability of `toMap` call and low speed of `as[T]/toMap/toSeq` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ val cat = json"""
 """
 assert(cat.name == name)                         // dynamic type
 assert(cat.age == age)
-val Some(catAge: Double) = cat.age.as[Double]    // type inference
+val Some(catAge: Int) = cat.age.asInt
 assert(catAge == age)
-assert(cat.age.as[Boolean] == None)
+assert(cat.age.asBoolean == None)
 
 val catMap = cat.toMap                           // view as a hashmap
 assert(catMap.keySet == Set("name", "age", "hobbies", "is cat"))
@@ -92,9 +92,9 @@ json.aString = "hi"                        // compiles
 json.aBoolean = true                       // compiles
 json.anInt = 23                            // compiles
 //json.somethingElse = Option("hi")       // does not compile
-val Some(i: Int) = json.anInt.as[Int]
+val Some(i: Int) = json.anInt.asInt
 assert(i == 23)
-assert(json.aBoolean.as[Int] == None)
+assert(json.aBoolean.asInt == None)
 ```
 
 See the [spec][1] for more examples.

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "0.54.0",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test

--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -7,7 +7,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
 import scala.annotation.switch
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
-import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe.{TypeTag, typeOf}
 
 package object dijon {
   type JsonTypes = ∅ ∨ String ∨ Int ∨ Double ∨ Boolean ∨ JsonArray ∨ JsonObject ∨ None.type
@@ -18,7 +18,7 @@ package object dijon {
 
   def `{}`: SomeJson = new util.LinkedHashMap[String, SomeJson].asScala
 
-  def `[]`: SomeJson = mutable.Buffer.empty[SomeJson]
+  def `[]`: SomeJson = new mutable.ArrayBuffer[SomeJson]
 
   implicit class Json[A : JsonType: TypeTag](val underlying: A) extends Dynamic {
     def selectDynamic(key: String): SomeJson = underlying match {
@@ -28,7 +28,7 @@ package object dijon {
 
     def updateDynamic(key: String)(value: SomeJson): Unit = underlying match {
       case obj: JsonObject => obj(key) = value
-      case _ =>
+      case _ => ()
     }
 
     def applyDynamic(key: String)(index: Int): SomeJson = underlying match {
@@ -39,7 +39,9 @@ package object dijon {
 
     def update(index: Int, value: SomeJson): Unit = underlying match {
       case arr: JsonArray if index >= 0 =>
-        while(arr.size <= index) { arr += None }
+        while (arr.size <= index) {
+          arr += None
+        }
         arr(index) = value
       case _ =>
     }
@@ -62,7 +64,7 @@ package object dijon {
 
     def remove(keys: String*): Unit = underlying match {
       case obj: JsonObject => obj --= keys
-      case _ => this
+      case _ => ()
     }
 
     def as[T : JsonType : TypeTag]: Option[T] = underlying match {

--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -4,10 +4,10 @@ import java.util
 
 import com.github.pathikrit.dijon.UnionType.{∅, ∨}
 import com.github.plokhotnyuk.jsoniter_scala.core._
+
 import scala.annotation.switch
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
-import scala.reflect.runtime.universe.{TypeTag, typeOf}
 
 package object dijon {
   type JsonTypes = ∅ ∨ String ∨ Int ∨ Double ∨ Boolean ∨ JsonArray ∨ JsonObject ∨ None.type
@@ -20,7 +20,7 @@ package object dijon {
 
   def `[]`: SomeJson = new mutable.ArrayBuffer[SomeJson]
 
-  implicit class Json[A : JsonType: TypeTag](val underlying: A) extends Dynamic {
+  implicit class Json[A : JsonType](val underlying: A) extends Dynamic {
     def selectDynamic(key: String): SomeJson = underlying match {
       case obj: JsonObject if obj contains key => obj(key)
       case _ => None
@@ -67,19 +67,39 @@ package object dijon {
       case _ => ()
     }
 
-    def as[T : JsonType : TypeTag]: Option[T] = underlying match {
-      case x: T if typeOf[A] <:< typeOf[T] => Some(x)
+    def asString: Option[String] = underlying match {
+      case x: String => Some(x)
       case _ => None
     }
 
-    def toMap: collection.Map[String, SomeJson] = as[JsonObject] match {
-      case Some(x) => x
-      case None => Map.empty
+    def asDouble: Option[Double] = underlying match {
+      case x: Double => Some(x)
+      case _ => None
     }
 
-    def toSeq: collection.Seq[SomeJson] = as[JsonArray] match {
-      case Some(x) => x
-      case None => Nil
+    def asInt: Option[Int] = underlying match {
+      case x: Int => Some(x)
+      case _ => None
+    }
+
+    def asBoolean: Option[Boolean] = underlying match {
+      case x: Boolean => Some(x)
+      case _ => None
+    }
+
+    def toSeq: collection.Seq[SomeJson] = underlying match {
+      case arr: JsonArray => arr
+      case _ => Nil
+    }
+
+    def toMap: collection.Map[String, SomeJson] = underlying match {
+      case obj: JsonObject => obj
+      case _ => Map.empty
+    }
+
+    def asNone: Option[None.type] = underlying match {
+      case x: None.type => Some(x)
+      case _ => None
     }
 
     override def toString: String = compact(this)

--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -72,13 +72,13 @@ package object dijon {
       case _ => None
     }
 
-    def toMap: Map[String, SomeJson] = as[JsonObject] match {
-      case Some(x) => x.toMap
-      case None => Map.empty[String, SomeJson]
+    def toMap: collection.Map[String, SomeJson] = as[JsonObject] match {
+      case Some(x) => x
+      case None => Map.empty
     }
 
-    def toSeq: Seq[SomeJson] = as[JsonArray] match {
-      case Some(x) => x.toSeq
+    def toSeq: collection.Seq[SomeJson] = as[JsonArray] match {
+      case Some(x) => x
       case None => Nil
     }
 

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -198,6 +198,11 @@ class DijonSpec extends WordSpec with Matchers {
 
       assert(cat == parse(cat.toString))   // round-trip test
 
+      cat.name.remove("something")         // do nothing
+      cat.age.remove("something")          // do nothing
+      cat.`is cat`.remove("something")     // do nothing
+      vet.phones.remove("something")       // do nothing
+
       var basicCat = cat -- "vet"                                  // remove 1 key
       basicCat = basicCat -- ("hobbies", "is cat", "paws")         // remove multiple keys ("paws" is not in cat)
       assert(basicCat == json"""{ "name": "Tigri", "age": 7}""")   // after dropping some keys above


### PR DESCRIPTION
Default hash maps in Scala handle collisions using an algorithm with `O(n^2)` complexity.

In this PR I propose to switch API from `Map/Seq` to `collection.Map/collection.Seq` and get `O(n*log(n))` complexity for the handling of hash map collisions. Please see bellow results of [benchmarks](https://github.com/plokhotnyuk/jsoniter-scala/pull/352) for parsing of JSON objects of different sizes when all keys have 0 value of hash code.
There is an option of using `mutable.CollisionProofHashMap`, but it still require of switching the type of result of the `toMap` call and should be ported for Scala 2.11.x/2.12.x for that (see https://github.com/scala/scala-collection-compat/issues/234).

Another option that can work for immutable result of `toMap` would be limiting numbers of keys that can be converted by `toMap`.

Yet another problem with too expensive `typeOf` calls that was detected by these benchmarks and raised [here](https://github.com/pathikrit/dijon/issues/30) is fixed in this PR by removing usage of Scala reflection. So instead of `as[Int]/as[String]/...` the following methods were implemented: `asInt/asString/...`. Also, the `asNone` method is added, here is a possible use case for it:
```
scala> import com.github.pathikrit.dijon._
import com.github.pathikrit.dijon._

scala> val j = json"""{"x":["1",null,{}]}"""
j: com.github.pathikrit.dijon.package.Json[Any] = {"x":["1",null,{}]}

scala> j.x.toSeq.filterNot(_.asNone.isDefined)
res0: scala.collection.Seq[com.github.pathikrit.dijon.package.SomeJson] = ArrayBuffer("1", {})
```

## Before
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                    (size)   Mode  Cnt        Score        Error  Units
[info] ExtractFieldsReading.dijonParse                   1  thrpt    3  2983289.709 ± 830261.728  ops/s
[info] ExtractFieldsReading.dijonParse                  10  thrpt    3   881482.792 ±  17872.802  ops/s
[info] ExtractFieldsReading.dijonParse                 100  thrpt    3    44245.410 ±   8167.595  ops/s
[info] ExtractFieldsReading.dijonParse                1000  thrpt    3     3884.390 ±     55.402  ops/s
[info] ExtractFieldsReading.dijonParse               10000  thrpt    3      295.359 ±     11.218  ops/s
[info] ExtractFieldsReading.dijonParse              100000  thrpt    3       23.642 ±     20.693  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap       1  thrpt    3    65960.415 ±  34599.506  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap      10  thrpt    3    54130.569 ±  27457.571  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap     100  thrpt    3    10956.483 ±   5704.414  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap    1000  thrpt    3      190.719 ±     14.853  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap   10000  thrpt    3        1.784 ±      1.016  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap  100000  thrpt    3        0.009 ±      0.001  ops/s
```
## After
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                    (size)   Mode  Cnt        Score         Error  Units
[info] ExtractFieldsReading.dijonParse                   1  thrpt    3  6274412.043 ±  562232.549  ops/s
[info] ExtractFieldsReading.dijonParse                  10  thrpt    3   978256.767 ±  292028.701  ops/s
[info] ExtractFieldsReading.dijonParse                 100  thrpt    3    42670.207 ±     526.796  ops/s
[info] ExtractFieldsReading.dijonParse                1000  thrpt    3     3090.553 ±    2022.896  ops/s
[info] ExtractFieldsReading.dijonParse               10000  thrpt    3      249.881 ±      86.810  ops/s
[info] ExtractFieldsReading.dijonParse              100000  thrpt    3       18.353 ±      10.673  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap       1  thrpt    3  6840144.250 ± 1362093.932  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap      10  thrpt    3   982408.460 ±  467516.116  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap     100  thrpt    3    40391.142 ±   29894.312  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap    1000  thrpt    3     3082.901 ±    3159.758  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap   10000  thrpt    3      250.402 ±     157.485  ops/s
[info] ExtractFieldsReading.dijonParseAndThenToMap  100000  thrpt    3       18.290 ±      16.433  ops/s
```