### PR TITLE
Make `++` and `--` yet more safe and efficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ assert(catAge == age)
 assert(cat.age.asBoolean == None)
 
 val catMap = cat.toMap                           // view as a hashmap
-assert(catMap.keySet == Set("name", "age", "hobbies", "is cat"))
+assert(catMap.toMap.keysIterator.toSeq == Seq("name", "age", "hobbies", "is cat"))
 
 assert(cat.hobbies(1) == "purring") // array access
 assert(cat.hobbies(100) == None)    // missing element

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -248,7 +248,7 @@ class DijonSpec extends FunSuite {
     assert(t.b.c.a == None)
   }
 
-  test("handle merges") {
+  test("handle deep merges") {
     val scala = json"""
       {
         "name": "scala",
@@ -281,6 +281,15 @@ class DijonSpec extends FunSuite {
 
     assert(scala == scalaCopy)       // original json objects stay untouched after merging
     assert(java == javaCopy)
+
+    val ab = json"""{"a":{"b":[0,1]}}"""
+    val ac = json"""{"a":{"c":[1,2]}}"""
+    val `ab++ac` = ab ++ ac          // merge result should be not affected by subsequent mutation of arguments
+    ab.a.b(0) = json"""5"""
+    ac.a.c(0) = json"""3"""
+    assert(ab == json"""{"a":{"b":[5,1]}}""")
+    assert(ac == json"""{"a":{"c":[3,2]}}""")
+    assert(`ab++ac` == json"""{"a":{"b":[0,1],"c":[1,2]}}""")
   }
 
   test("be type-safeish") {

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -75,7 +75,7 @@ class DijonSpec extends FunSuite {
     assert(rick.hobbies(4) == None)
     assert(rick.undefined(0) == None)
 
-    assert(rick.toMap.keySet == Set("name", "age", "class", "contact", "is online", "weight", "hobbies", "toMap"))
+    assert(rick.toMap.keysIterator.toSeq == List("name", "age", "class", "weight", "is online", "contact", "hobbies", "toMap"))
     assert(rick.selectDynamic("toMap")(1) == 345)
     assert(rick == parse(rick.toString)) // round-trip test
     assert(rick.toSeq.isEmpty == true)
@@ -184,7 +184,7 @@ class DijonSpec extends FunSuite {
     assert(cat.age.asBoolean.isEmpty)
 
     val catMap = cat.toMap                           // view as a hashmap
-    assert(catMap.keySet == Set("name", "age", "temperature", "hobbies", "is cat"))
+    assert(catMap.toMap.keysIterator.toSeq == Seq("name", "hobbies", "is cat", "temperature", "age"))
 
     assert(cat.hobbies(1) == "purring") // array access
     assert(cat.hobbies(100) == None)    // missing element


### PR DESCRIPTION
Now without an internal `toSet` call that isn't safe, see: scala/bug#11203

@pathikrit Could you please check, merge and cut the 0.3.1 release?