### PR TITLE
add string indexing using apply and applyDynamic, JsonObject and JsonArray constructor functions

### DIFF
--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -93,6 +93,11 @@ package object dijon {
       case _ =>
     }
 
+    def update(index: String, value: SomeJson): Unit = underlying match {
+      case obj: JsonObject => obj(index) = value
+      case _ =>
+    }
+
     def ++(that: SomeJson): SomeJson = (this.underlying, that.underlying) match {
       case (a: JsonObject, b: JsonObject) =>
         val res = new util.LinkedHashMap[String, SomeJson](a.size + b.size)

--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -17,7 +17,7 @@ package object dijon {
   type JsonObject = mutable.Map[String, SomeJson]
   type JsonArray = mutable.Buffer[SomeJson]
 
-  def JsonObject(values: (String, SomeJson)*): JsonObject = {
+  def JsonObject(values: (String, SomeJson)*): SomeJson = {
     val map = new util.LinkedHashMap[String,SomeJson](values.length).asScala
     for ((k,v) <- values) {
       map.put(k,v)
@@ -25,7 +25,7 @@ package object dijon {
     map
   }
 
-  def JsonArray(values: SomeJson*): JsonArray = {
+  def JsonArray(values: SomeJson*): SomeJson = {
     mutable.ArrayBuffer[SomeJson](values: _*)
   }
 

--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -57,33 +57,32 @@ package object dijon {
       case _ => None
     }
 
-    def applyDynamic(key: String): JsonApplyDynamic = new JsonApplyDynamic(key)
-
-    class JsonApplyDynamic(key: String) {
-      def apply(index: Int): SomeJson = underlying match {
-          case obj: JsonObject => obj.get(key) match {
-            case Some(value) => value.underlying match {
-              case arr: JsonArray if arr.isDefinedAt(index) => arr(index)
-              case _ => None
-            }
+    def applyDynamic[B](key: String)(index: Any): SomeJson = index match {
+      case index: Int => underlying match {
+        case obj: JsonObject => obj.get(key) match {
+          case Some(value) => value.underlying match {
+            case arr: JsonArray if arr.isDefinedAt(index) => arr(index)
             case _ => None
           }
-          case arr: JsonArray if key == "apply" && arr.isDefinedAt(index) => arr(index)
           case _ => None
+        }
+        case arr: JsonArray if key == "apply" && arr.isDefinedAt(index) => arr(index)
+        case _ => None
       }
-      def apply(index: String): SomeJson = underlying match {
-          case obj: JsonObject if key != "apply" => obj.get(key) match {
-            case Some(value) => value.underlying match {
-              case obj2: JsonObject if obj2.contains(index) => obj2(index)
-              case _ => None
-            }
+      case index: String => underlying match {
+        case obj: JsonObject if key != "apply" => obj.get(key) match {
+          case Some(value) => value.underlying match {
+            case obj2: JsonObject if obj2.contains(index) => obj2(index)
             case _ => None
           }
-          case obj: JsonObject if key == "apply" && obj.contains(index) => obj(index)
           case _ => None
+        }
+        case obj: JsonObject if key == "apply" && obj.contains(index) => obj(index)
+        case _ => None
       }
+      case _ => None
     }
-
+    
     def update(index: Int, value: SomeJson): Unit = underlying match {
       case arr: JsonArray if index >= 0 =>
         while (arr.length <= index) {

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -118,7 +118,7 @@ class DijonSpec extends AnyFunSuite {
     val updateTest = `{}`
     updateTest("arr") = JsonArray(1,2,3)
     updateTest.obj = JsonObject("a"->1, "b"->2)
-    updateText("obj")("c") = 3
+    updateTest("obj")("c") = 3
     assert(updateTest.toString == """{"obj":{"a":1,"b":2,"c":3},"arr":[1,2,3]}""")
 
     assert(pretty(rick) ==

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -106,12 +106,12 @@ class DijonSpec extends AnyFunSuite {
        "hobbies"->JsonArray(
          "eating",
          JsonObject(
-           "games"->JsonObject("chess"->true, "football"->false),
+           "games"->JsonObject("chess"->true, "football"->false)
          ),
          JsonArray("coding", JsonArray("python", "scala")),
-         None,
+         None
         ),
-        "toMap"->JsonArray(23, 345, true),
+        "toMap"->JsonArray(23, 345, true)
      ).toString
     )
 

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -81,6 +81,40 @@ class DijonSpec extends AnyFunSuite {
     assert(rick == parse(rick.toString)) // round-trip test
     assert(rick.toSeq.isEmpty == true)
 
+    assert(rick("hobbies")(2)(0) == "coding")
+    assert(rick("hobbies")(2)(1)(1) == "scala")
+    assert(rick("hobbies")(2)(100) == None)
+    assert(rick("hobbies")(1).games.football.asBoolean == Some(false))
+    assert(rick("hobbies")(1)("games").football.asInt == None)
+    assert(rick("hobbies")(1).games("foosball").asBoolean == None)
+    assert(rick("hobbies")(3) == None)
+    assert(rick("hobbies")(4) == None)
+    assert(rick("undefined")(0) == None)
+    assert(rick.toString == JsonObject(
+      "name"->name,
+      "age"->age,
+      "class"->"human",
+      "weight"->175.1,
+      "is online"->true,
+      "contact"->JsonObject(
+        "emails"->JsonArray(email1, email2),
+        "phone"->JsonObject(
+          "home"->"817-xxx-xxx",
+          "work"->"650-xxx-xxx"
+         )
+       ),
+       "hobbies"->JsonArray(
+         "eating",
+         JsonObject(
+           "games"->JsonObject("chess"->true, "football"->false),
+         ),
+         JsonArray("coding", JsonArray("python", "scala")),
+         None,
+        ),
+        "toMap"->JsonArray(23, 345, true),
+     ).toString
+    )
+
     assert(pretty(rick) ==
       """{
         |  "name": "Rick",

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -116,9 +116,9 @@ class DijonSpec extends AnyFunSuite {
     )
 
     val updateTest = `{}`
-    updateTest("arr") = JsonArray(1,2,3)
     updateTest.obj = JsonObject("a"->1, "b"->2)
     updateTest("obj")("c") = 3
+    updateTest("arr") = JsonArray(1,2,3)
     assert(updateTest.toString == """{"obj":{"a":1,"b":2,"c":3},"arr":[1,2,3]}""")
 
     assert(pretty(rick) ==

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -115,6 +115,12 @@ class DijonSpec extends AnyFunSuite {
      ).toString
     )
 
+    val updateTest = `{}`
+    updateTest("arr") = JsonArray(1,2,3)
+    updateTest.obj = JsonObject("a"->1, "b"->2)
+    updateText("obj")("c") = 3
+    assert(updateTest.toString == """{"obj":{"a":1,"b":2,"c":3},"arr":[1,2,3]}""")
+
     assert(pretty(rick) ==
       """{
         |  "name": "Rick",


### PR DESCRIPTION
This pull request adds two features:

1. `JsonObject()` and `JsonArray()` constructor functions. These are useful for building up more complex Json types, and they are more composable than the `json""` StringContext approach:

```
JsonObject(
      "name"->name,
      "age"->age,
      "class"->"human",
      "weight"->175.1,
      "is online"->true,
      "contact"->JsonObject(
        "emails"->JsonArray(email1, email2),
        "phone"->JsonObject(
          "home"->"817-xxx-xxx",
          "work"->"650-xxx-xxx"
         )
       ),
       "hobbies"->JsonArray(
         "eating",
         JsonObject(
           "games"->JsonObject("chess"->true, "football"->false)
         ),
         JsonArray("coding", JsonArray("python", "scala")),
         None
        ),
        "toMap"->JsonArray(23, 345, true)
     ).toString // result is JSON string
```

2. The ability to index `JsonObject`s using String indexes in addition to the existing `selectDynamic` approach. This allows for object lookups using variables instead of just literal values. This could already be accomplished by calling `selectDynamic` directly, but IMHO it's more ergonomic and aesthetically pleasing this way:

```
val h = "hobbies"
rick(h)(2)(0) == "coding"
```